### PR TITLE
Source regardless of g:rainbow_active existence

### DIFF
--- a/plugin/rainbow.vim
+++ b/plugin/rainbow.vim
@@ -17,7 +17,7 @@
 "	:RainbowToggle		--you can use it to toggle this plugin.
 "==============================================================================
 
-if exists('s:loaded') || !(exists('g:rainbow_active') || exists('g:rainbow_conf'))
+if exists('s:loaded') || exists('g:rainbow_conf'))
 	finish
 endif
 let s:loaded = 1


### PR DESCRIPTION
I think it's kind of unexpected to source the plugin only when `g:rainbow_active` is defined.

If you want to use it sporadically through the `:RainbowToggle` command, having to set `g:rainbow_active` to 0 doesn't really follow the principle of least astonishment.
