### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install:
 ### via Vundle:
 
 ```vim
-Bundle 'luochen1990/rainbow'
+Plugin 'luochen1990/rainbow'
 let g:rainbow_active = 1 "0 if you want to enable it later via :RainbowToggle
 ```
 


### PR DESCRIPTION
Vundle now uses the keyword `Plugin` instead of `Bundle` for loading plugins.
