### PR TITLE
Make a cluster for using in different regions

### DIFF
--- a/plugin/rainbow.vim
+++ b/plugin/rainbow.vim
@@ -101,6 +101,11 @@ func rainbow#load()
 			exe printf(def_rg, 'rainbow_r0', 'rainbow_p0 contained', containedin.',rainbow_r'.(maxlvl - 1), contains, paren)
 		endif
 	endfor
+	syn cluster rainbow_cluster contains=rainbow_r0
+	for lvl in range(maxlvl)
+		let def_clust = "syn cluster rainbow_cluster add = rainbow_r".lvl
+	endfor
+	exe def_clust
 	call rainbow#show()
 endfunc
 


### PR DESCRIPTION
Please let me know if this functionality already exists, but I could not figure it out.

In the case where there are different syntax regions in a file, parentheses are not highlighted by rainbow in the interior region.  For example, at this link (http://vim.wikia.com/wiki/Different_syntax_highlighting_within_regions_of_a_file), within the CPP region defined by `@begin=cpp@` and `@end=cpp@` I could not figure out how to turn on the rainbow parentheses.  So what I did was define a cluster of all the `rainbow_r0..maxlvl` and now applying

```
:syntax region cppSnip matchgroup=Snip start="@begin=cpp@" end="@end=cpp@" contains=@CPP,@rainbow_cluster
```

highlights the parentheses with rainbow.  Again, if there is already a way to do this, please let me know. 

Thanks!
