### PR TITLE
Create Rainbow Syntax Cluster

### DIFF
--- a/plugin/rainbow.vim
+++ b/plugin/rainbow.vim
@@ -9,8 +9,8 @@
 "	 	let g:rainbow_active = 1
 "	third, restart your vim and enjoy coding.
 "Advanced Configuration:
-"	an advanced configuration allows you to define what parentheses to use 
-"	for each type of file . you can also determine the colors of your 
+"	an advanced configuration allows you to define what parentheses to use
+"	for each type of file . you can also determine the colors of your
 "	parentheses by this way (read file vim73/rgb.txt for all named colors).
 "	READ THE SOURCE FILE FROM LINE 25 TO LINE 50 FOR EXAMPLE.
 "User Command:
@@ -104,6 +104,14 @@ func rainbow#load()
 			exe printf(def_rg, 'rainbow_r0', 'rainbow_p0 contained', containedin.',rainbow_r'.(maxlvl - 1), contains, paren)
 		endif
 	endfor
+
+	let cluster_list = []
+	for each in range(b:rainbow_loaded)
+		call add(cluster_list, 'rainbow_r'.each)
+	endfor
+
+	exe 'syn cluster RainbowRegions contains='.join(cluster_list,',')
+
 	call rainbow#show()
 endfunc
 


### PR DESCRIPTION
When highlighting nested regions for certain languages (like Javascript for instance) the start and end parameters of those regions overlaps with the start and end matches of the Rainbow parenthesis.  Most of the time this is not an insurmountable problem - you can get around it with clever use of look aheads.

But if you want to utilize the 'contains' or 'containedin' parameters of a vim syntax region, you cannot, since the `rainbow_r{x}` regions are dynamically generated.

This adds a `RainbowRegions` syntax cluster for all of the defined rainbow regions, allowing you to use the various `contains` parameters when syntax highlighting.