### PR TITLE
Add cterm gui formatting options

### DIFF
--- a/plugin/rainbow.vim
+++ b/plugin/rainbow.vim
@@ -25,6 +25,8 @@ let s:loaded = 1
 let s:rainbow_conf = {
 \	'guifgs': ['royalblue3', 'darkorange3', 'seagreen3', 'firebrick'],
 \	'ctermfgs': ['lightblue', 'lightyellow', 'lightcyan', 'lightmagenta'],
+\	'guis': ['bold'],
+\	'cterms': ['bold'],
 \	'operators': '_,_',
 \	'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/{/ end=/}/ fold'],
 \	'separately': {
@@ -131,8 +133,10 @@ func rainbow#show()
 		for id in range(b:rainbow_loaded)
 			let ctermfg = b:rainbow_conf.ctermfgs[id % len(b:rainbow_conf.ctermfgs)]
 			let guifg = b:rainbow_conf.guifgs[id % len(b:rainbow_conf.guifgs)]
-			exe 'hi rainbow_p'.id.' ctermfg='.ctermfg.' guifg='.guifg
-			exe 'hi rainbow_o'.id.' ctermfg='.ctermfg.' guifg='.guifg
+			let cterm = b:rainbow_conf.cterms[id % len(b:rainbow_conf.cterms)]
+			let gui = b:rainbow_conf.cterms[id % len(b:rainbow_conf.cterms)]
+			exe 'hi rainbow_p'.id.' ctermfg='.ctermfg.' guifg='.guifg.' cterm='.cterm.' gui='.gui
+			exe 'hi rainbow_o'.id.' ctermfg='.ctermfg.' guifg='.guifg.' cterm='.cterm.' gui='.gui
 		endfor
 	endif
 endfunc


### PR DESCRIPTION
I like to have parens printed out bold. That wasn't easily achievable
with rainbow as one had to add `hi rainbow_pX` options for each level.
So I've added an option to pass `cterm` and `gui` config options in a
similar way as for `ctermfg` and `guifg`.

While doing this I was thinking that there is missing more actually:

* `(cterm|gui)bg`
* `term(fg|bg)`

Should we add those as well? If configured the same way as the `fg`s,
we'd have 9 options for highlights in the settings.