### PR TITLE
style: use ==# instead of just ==

### DIFF
--- a/autoload/rainbow.vim
+++ b/autoload/rainbow.vim
@@ -5,11 +5,11 @@ fun s:resolve_parenthesis(p)
 	let [paren, containedin, contains, op] = ['', '', 'TOP', '']
 	for s in ls
 		let [k, v] = [matchstr(s, '^[^=]\+\ze='), matchstr(s, '^[^=]\+=\zs.*')]
-		if k == 'step'
+		if k ==# 'step'
 			let op = v
-		elseif k == 'contains'
+		elseif k ==# 'contains'
 			let contains = v
-		elseif k == 'containedin'
+		elseif k ==# 'containedin'
 			let containedin = v
 		else
 			let paren .= s
@@ -26,7 +26,7 @@ fun rainbow#syn(config)
 		let p = conf.parentheses[i]
 		if type(p) == type([])
 			let op = len(p)==3? p[1] : has_key(conf, 'operators')? conf.operators : ''
-			let conf.parentheses[i] = op != ''? printf('start=#%s# step=%s end=#%s#', p[0], op, p[-1]) : printf('start=#%s# end=#%s#', p[0], p[-1])
+			let conf.parentheses[i] = op !=# ''? printf('start=#%s# step=%s end=#%s#', p[0], op, p[-1]) : printf('start=#%s# end=#%s#', p[0], p[-1])
 		endif
 	endfor
 	let def_rg = 'syn region %s matchgroup=%s containedin=%s contains=%s %s'
@@ -35,18 +35,18 @@ fun rainbow#syn(config)
 	let b:rainbow_loaded = cycle
 	for parenthesis_args in conf.parentheses
 		let [paren, containedin, contains, op] = s:resolve_parenthesis(parenthesis_args)
-		if op == '' |let op = conf.operators |endif
+		if op ==# '' |let op = conf.operators |endif
 		for lvl in range(cycle)
-			if len(op) > 0 && op !~ '^..\s*$' |exe printf(def_op, prefix.'_o'.lvl, op, prefix.'_r'.lvl) |endif
+			if len(op) > 0 && op !~? '^..\s*$' |exe printf(def_op, prefix.'_o'.lvl, op, prefix.'_r'.lvl) |endif
 			if lvl == 0
-				if containedin == ''
+				if containedin ==# ''
 					exe printf(def_rg, prefix.'_r0', prefix.'_p0', prefix.'_r'.(cycle - 1), contains, paren)
 				endif
 			else
 				exe printf(def_rg, prefix.'_r'.lvl, prefix.'_p'.lvl.(' contained'), prefix.'_r'.((lvl + cycle - 1) % cycle), contains, paren)
 			endif
 		endfor
-		if containedin != ''
+		if containedin !=# ''
 			exe printf(def_rg, prefix.'_r0', prefix.'_p0 contained', containedin.','.prefix.'_r'.(cycle - 1), contains, paren)
 		endif
 	endfor


### PR DESCRIPTION
`==` can have different meaning depending on `&ignorecase`.

`==#` _always_ means case is significant.