### PR TITLE
fix misspelled arg `cterm`

### DIFF
--- a/autoload/rainbow_main.vim
+++ b/autoload/rainbow_main.vim
@@ -83,7 +83,7 @@ fun rainbow_main#gen_config(ft)
 		return 0
 	else
 		let conf = extend(extend({'syn_name_prefix': substitute(a:ft, '\v\A+(\a)', '\u\1', 'g').'Rainbow'}, dft_conf), af_conf)
-		let conf.cycle = has('gui_running')? s:lcm(len(conf.guifgs), len(conf.guis)) : s:lcm(len(conf.ctermfgs), len(conf.cterm))
+		let conf.cycle = has('gui_running')? s:lcm(len(conf.guifgs), len(conf.guis)) : s:lcm(len(conf.ctermfgs), len(conf.cterms))
 		return conf
 	endif
 endfun


### PR DESCRIPTION
conf arg `cterms` is misspelled to `cterm` in `rainbow_main#gen_config`, fix it.