### PR TITLE
add support for ocaml files

### DIFF
--- a/autoload/rainbow_main.vim
+++ b/autoload/rainbow_main.vim
@@ -20,6 +20,9 @@ let s:rainbow_conf = {
 \		'haskell': {
 \			'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/\v\{\ze[^-]/ end=/}/ fold'],
 \		},
+\		'ocaml': {
+\			'parentheses': ['start=/(\ze[^*]/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/\[|/ end=/|\]/ fold', 'start=/{/ end=/}/ fold'],
+\		},
 \		'tex': {
 \			'parentheses_options': 'containedin=texDocZone',
 \			'parentheses': ['start=/(/ end=/)/', 'start=/\[/ end=/\]/'],


### PR DESCRIPTION
Before this PR, OCaml comments (`(* ... *)`) were wrongly syntax-highlighted, and there was problem with arrays (`[| ... |]`) where `|]` was highlighted as an error. This PR fixes both problems. See the before/after screenshots below:

Before:
![before](https://i.imgur.com/5OdWNKV.png)

After:
![after](https://i.imgur.com/m0AfdfD.png)