### PR TITLE
Avoid single line if statements

### DIFF
--- a/autoload/rainbow.vim
+++ b/autoload/rainbow.vim
@@ -1,6 +1,9 @@
 " Copyright 2013 LuoChen (luochen1990@gmail.com). Licensed under the Apache License 2.0.
 
-if exists('s:loaded') | finish | endif | let s:loaded = 1
+if exists('s:loaded')
+  finish
+endif
+let s:loaded = 1
 
 fun s:trim(s)
 	return substitute(a:s, '\v^\s*(.{-})\s*$', '\1', '')
@@ -79,7 +82,11 @@ fun rainbow#syn(config)
 	exe 'syn cluster '.prefix.'Regions contains='.join(map(range(cycle), '"@".s:synGroupID(prefix, "Regions", v:val)'), ',')
 	exe 'syn cluster '.prefix.'Parentheses contains='.join(map(range(cycle), '"@".s:synGroupID(prefix, "Parentheses", v:val)'), ',')
 	exe 'syn cluster '.prefix.'Operators contains='.join(map(range(cycle), '"@".s:synGroupID(prefix, "Operators", v:val)'), ',')
-	if has_key(conf, 'after') | for cmd in conf.after | exe cmd | endfor | endif
+	if has_key(conf, 'after')
+      for cmd in conf.after
+        exe cmd
+      endfor
+    endif
 endfun
 
 fun rainbow#syn_clear(config)

--- a/autoload/rainbow_main.vim
+++ b/autoload/rainbow_main.vim
@@ -114,7 +114,9 @@ fun rainbow_main#load()
 endfun
 
 fun rainbow_main#clear()
-	if !exists('b:rainbow_confs') | return | endif
+	if !exists('b:rainbow_confs')
+      return
+    endif
 	for conf in b:rainbow_confs
 		call rainbow#hi_clear(conf)
 		call rainbow#syn_clear(conf)

--- a/plugin/rainbow_main.vim
+++ b/plugin/rainbow_main.vim
@@ -1,6 +1,9 @@
 " Copyright 2013 LuoChen (luochen1990@gmail.com). Licensed under the Apache License 2.0.
 
-if exists('s:loaded') || !(exists('g:rainbow_active') || exists('g:rainbow_conf')) | finish | endif | let s:loaded = 1
+if exists('s:loaded') || !(exists('g:rainbow_active') || exists('g:rainbow_conf'))
+  finish
+endif
+let s:loaded = 1
 
 command! RainbowToggle call rainbow_main#toggle()
 command! RainbowToggleOn call rainbow_main#load()


### PR DESCRIPTION
There's a bug with vim (neovim?) where inline `if cond | return | endif` style commands can result in errors such as this one.
```
:%s/
Error detected while processing ~/.local/share/nvim/plugged/rainbow/autoload/rainbow.vim:
line  129:
E171: Missing :endif
Error detected while processing function rainbow_main#load:
line    3:
E117: Unknown function: rainbow#syn
Error detected while processing ~/.local/share/nvim/plugged/rainbow/autoload/rainbow.vim:
line  129:
E171: Missing :endif
Error detected while processing function rainbow_main#load:
line    4:
E117: Unknown function: rainbow#hi
Press ENTER or type command to continue
```
This can be reproduced by opening neovim and pressing `:%s/<C-f>`.

Replacing the inline if statements with multiple line ones fixes the issue.