### PR TITLE
Add folder creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ let g:rainbow_active = 1 "set to 0 if you want to enable it later via :RainbowTo
 	```sh
 	git clone https://github.com/luochen1990/rainbow.git
 	cd rainbow
+	mkdir -p ~/.vim/plugin
 	cp plugin/* ~/.vim/plugin
 	cp autoload/* ~/.vim/autoload
 	```


### PR DESCRIPTION
If the user does not have a `~/.vim/plugin` folder then the command `cp plugin/* ~/.vim/plugin` will copy the file `plugin/rainbow_main.vim` to `~/.vim/plugin` which will not work.