### PR TITLE
Fixed for lua long bracket strings

### DIFF
--- a/autoload/rainbow_main.vim
+++ b/autoload/rainbow_main.vim
@@ -41,6 +41,9 @@ let s:rainbow_conf = {
 \		'html': {
 \			'parentheses': ['start=/\v\<((script|style|area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)[ >])@!\z([-_:a-zA-Z0-9]+)(\s+[-_:a-zA-Z0-9]+(\=("[^"]*"|'."'".'[^'."'".']*'."'".'|[^ '."'".'"><=`]*))?)*\>/ end=#</\z1># fold'],
 \		},
+\		'lua': {
+\			'parentheses': ["start=/(/ end=/)/", "start=/{/ end=/}/", "start=/\\v\\[\\ze($|[^[])/ end=/\\]/"],
+\		},
 \		'perl': {
 \			'syn_name_prefix': 'perlBlockFoldRainbow',
 \		},

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -1,0 +1,12 @@
+(function(args)
+    lst = { a=function(arg) print("hello") end,
+             b=(1+2)*3/4,
+             [3+5]={ ["hello"]=("hi") },
+         }
+    lst[
+    (function() return 0 end)()] = 1
+end)("blah")
+
+[[
+Special lua string...
+]]


### PR DESCRIPTION
The default setting fails on such lua strings:
```lua
[[ Blah ]]
```
Adding a rule to avoid matching and highlighting the first `[` may fix this.