### PR TITLE
add < > document example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ let g:rainbow_conf = {
 \	'guis': [''],
 \	'cterms': [''],
 \	'operators': '_,_',
-\	'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/{/ end=/}/ fold'],
+\	'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/{/ end=/}/ fold', 'start=/<\\ze\\S/ end=/>/ fold'],
 \	'separately': {
 \		'*': {},
 \		'markdown': {

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ let g:rainbow_active = 1 "0 if you want to enable it later via :RainbowToggle
 	\	'guifgs': ['royalblue3', 'darkorange3', 'seagreen3', 'firebrick'],
 	\	'ctermfgs': ['lightblue', 'lightyellow', 'lightcyan', 'lightmagenta'],
 	\	'operators': '_,_',
-	\	'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/{/ end=/}/ fold'],
+	\	'parentheses': ['start=/(/ end=/)/ fold', 'start=/\[/ end=/\]/ fold', 'start=/{/ end=/}/ fold', 'start=/<\\ze\\S/ end=/>/ fold'],
 	\	'separately': {
 	\		'*': {},
 	\		'tex': {


### PR DESCRIPTION
文档里面例子增加<>，支持c++的容器嵌套高亮，同时避免和运算符冲突
![image](https://github.com/user-attachments/assets/3959174d-2114-44c9-b72c-d376795302c0)
